### PR TITLE
fix plugin helm to support array

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,8 @@ controller:
         - name: consul-plugin
           mountPath: /plugin-bin/hashicorp
   trafficRouterPlugins:
-    trafficRouterPlugins: |-
-      - name: "hashicorp/consul"
-        location: "file:///plugin-bin/hashicorp/rollouts-plugin-trafficrouter-consul"
+    - name: "hashicorp/consul"
+      location: "file:///plugin-bin/hashicorp/rollouts-plugin-trafficrouter-consul"
   volumes:
     - name: consul-plugin
       emptyDir: {}
@@ -60,9 +59,8 @@ To build the binary and install Rollouts, complete the following steps:
 ```yaml
 controller:
   trafficRouterPlugins:
-    trafficRouterPlugins: |-
-      - name: "argoproj-labs/consul"
-        location: "file:///plugin-bin/hashicorp/rollouts-plugin-trafficrouter-consul"
+    - name: "argoproj-labs/consul"
+      location: "file:///plugin-bin/hashicorp/rollouts-plugin-trafficrouter-consul"
   volumes:
     - name: consul-route-plugin
       hostPath:
@@ -129,9 +127,13 @@ metadata:
   name: argo-rollouts-config
   namespace: argo-rollouts
 data:
-  trafficRouterPlugins: |-
-    - name: "argoproj-labs/consul"
-      location: "file:///plugin-bin/hashicorp/rollouts-plugin-trafficrouter-consul"
+  trafficRouterPlugins: |
+      [
+        {
+          "name": "argoproj-labs/consul",
+          "location" : "file:///plugin-bin/hashicorp/rollouts-plugin-trafficrouter-consul"
+        }
+      ]      
 binaryData: {}
 ```
 

--- a/testing/README.MD
+++ b/testing/README.MD
@@ -7,8 +7,11 @@ This is for building and testing argo rollout integrations with Consul. For simp
 3. Kubectl is installed on the machine (`brew install kubectl`)
 4. Argo kubectl extension is installed on the machine (`brew install argoproj/tap/kubectl-argo-rollouts`)
 5. The plugin binary is in a directory on the machine
-6. yq is installed, this is required for running some scripts
-7. Update any of the necessary variables in the `Makefile` to match your environment
+6. yq is installed, this is required for running some scripts (`brew install yq`)
+7. jq is installed, this is required for running some scripts (`brew install jq`)
+8. Hashicorp repo is added to Helm (`helm repo add hashicorp https://helm.releases.hashicorp.com`)
+9. Argo repo is added to Helm (`helm repo add argo https://argoproj.github.io/argo-helm`)
+10. Update any of the necessary variables in the `Makefile` to match your environment
 
 # Verify v1 to v2 rollout
 1. Run `make setup` to setup the system with the static-server/client, consul and argo. This will also build the latest plugin.

--- a/testing/makefile
+++ b/testing/makefile
@@ -1,7 +1,12 @@
 KUBERNETES_VERSION = v1.25.11
 CONSUL_K8S_CHART_VERSION = 1.3.1
 PLUGIN_DIR= $(shell realpath ../)
-IMAGE=hashicorp/rollouts-plugin-trafficrouter-consul:0.0.1-alpha1
+IMAGE=hashicorp/rollouts-plugin-trafficrouter-consul:latest
+
+ARGO_CHART_VERSION = 2.39.0
+ARGO_CONTROLLER_REGISTRY = quay.io
+ARGO_CONTROLLER_REPOSITORY = argoproj/argo-rollouts
+ARGO_CONTROLLER_TAG = latest
 
 #Do Not change
 VALUES_INIT_HELM=values_rollout_init.yaml
@@ -79,7 +84,7 @@ argo-setup: deploy-argo apply-crds
 .PHONY: deploy-argo
 deploy-argo:
 	kubectl create namespace argo-rollouts; \
-	helm install argo-rollouts argo/argo-rollouts -f values_rollout.yaml -n argo-rollouts; \
+	helm install argo-rollouts argo/argo-rollouts --version $(ARGO_CHART_VERSION) -f values_rollout.yaml -n argo-rollouts; \
 	kubectl apply -f $(PLUGIN_DIR)/yaml/rbac.yaml
 
 .PHONY: apply-crds
@@ -117,7 +122,7 @@ argo-image-values:
 .PHONY: deploy-argo-image
 deploy-argo-image:
 	kubectl create namespace argo-rollouts; \
-	helm install argo-rollouts argo/argo-rollouts -f $(VALUES_INIT_HELM) -n argo-rollouts; \
+	helm install argo-rollouts argo/argo-rollouts --version $(ARGO_CHART_VERSION) -f $(VALUES_INIT_HELM) -n argo-rollouts; \
 	kubectl apply -f $(PLUGIN_DIR)/yaml/rbac.yaml
 
 ## EXTRAS

--- a/testing/scripts/create_values_rollout_https_helm.sh
+++ b/testing/scripts/create_values_rollout_https_helm.sh
@@ -9,23 +9,25 @@ fi
 # New host path
 helm_file=$1
 binary=$2
+registry=$3
+repository=$4
+tag=$5
 
 # Create the YAML structure and write it to kind_config_file
 cat << EOF > "$helm_file"
 controller:
   image:
     # -- Registry to use
-    registry: docker.io
+    registry: $registry
     # -- Repository to use
-    repository: wilko1989/argo-rollouts
+    repository: $repository
     # -- Overrides the image tag (default is the chart appVersion)
-    tag: latest
+    tag: $tag
     # -- Image pull policy
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   trafficRouterPlugins:
-    trafficRouterPlugins: |-
-      - name: "hashicorp/consul"
-        location: $binary # supports http(s):// urls and file://
+    - name: "hashicorp/consul"
+      location: $binary # supports http(s):// urls and file://
   volumes:
     - name: consul-plugin
       emptyDir: {}

--- a/testing/scripts/create_values_rollout_init_helm.sh
+++ b/testing/scripts/create_values_rollout_init_helm.sh
@@ -9,19 +9,22 @@ fi
 # New host path
 helm_file=$1
 image=$2
+registry=$3
+repository=$4
+tag=$5
 
 # Create the YAML structure and write it to kind_config_file
 cat << EOF > "$helm_file"
 controller:
   image:
     # -- Registry to use
-    registry: docker.io
+    registry: $registry
     # -- Repository to use
-    repository: wilko1989/argo-rollouts
+    repository: $repository
     # -- Overrides the image tag (default is the chart appVersion)
-    tag: latest
+    tag: $tag
     # -- Image pull policy
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   initContainers:
     - name: copy-consul-plugin
       image: $image
@@ -33,9 +36,8 @@ controller:
         - name: consul-plugin
           mountPath: /plugin-bin/hashicorp
   trafficRouterPlugins:
-    trafficRouterPlugins: |-
-      - name: "hashicorp/consul"
-        location: "file:///plugin-bin/hashicorp/rollouts-plugin-trafficrouter-consul"
+    - name: "hashicorp/consul"
+      location: "file:///plugin-bin/hashicorp/rollouts-plugin-trafficrouter-consul"
   volumes:
     - name: consul-plugin
       emptyDir: {}

--- a/testing/values_rollout.yaml
+++ b/testing/values_rollout.yaml
@@ -1,17 +1,16 @@
 controller:
   image:
     # -- Registry to use
-    registry: docker.io
+    registry: quay.io
     # -- Repository to use
-    repository: wilko1989/argo-rollouts
+    repository: argoproj/argo-rollouts
     # -- Overrides the image tag (default is the chart appVersion)
-    tag: latest
+    tag: ""
     # -- Image pull policy
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   trafficRouterPlugins:
-    trafficRouterPlugins: |-
-      - name: "hashicorp/consul"
-        location: "file:///plugin-bin/hashicorp/rollouts-plugin-trafficrouter-consul"
+    - name: "hashicorp/consul"
+      location: "file:///plugin-bin/hashicorp/rollouts-plugin-trafficrouter-consul"
   volumes:
     - name: consul-route-plugin
       hostPath:


### PR DESCRIPTION
`trafficRouterPlugins` was changed to an array type, meaning tests and documentation needed to be updated

## Discovery
- Ran testing suite and noticed the pod for the argo controller was failing to start
- Looked at pod logs, noticed that the trafficRouterPlugins could no longer be unmarshalled
- Tried older helm chart version and verified that the argo controller was now able to start
- Looked at argo helm chart changes and noticed the `trafficRouterPlugins` had been [changed to an array type](https://github.com/argoproj/argo-helm/commit/ccfa0651cba45454d7462dcb153d4222ef1feb72#diff-aa94ff426900305cbc863f3f177b789e84a1163b420ad8afd28b43f82c67a2a8R130)

## Testing:
Ran testing suite and verified that the argo controller starts up and that all tests now pass